### PR TITLE
prevent context menu

### DIFF
--- a/GraphEditor/graphEditor.js
+++ b/GraphEditor/graphEditor.js
@@ -23,6 +23,9 @@ TODO: Task list tracked at
 -----------------------------------------------------------------------------*/
 "use strict";
 
+// Prevent context menu
+document.addEventListener('contextmenu', event => event.preventDefault());
+
 // set up the SVG
 var width  = 1400,
   height = 600,


### PR DESCRIPTION
Removes context menu from the page. Makes ctrl+click user friendly on
mac computers.